### PR TITLE
Easier user support

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -7,7 +7,7 @@ ARG VERSION
 LABEL build_version="Linuxserver.io version:- ${VERSION} Build-date:- ${BUILD_DATE}"
 
 # environment settings
-ENV NPM_CONFIG_LOGLEVEL info
+ENV NPM_CONFIG_LOGLEVEL=info USERS=no
 
 # install packages
 RUN \

--- a/README.md
+++ b/README.md
@@ -34,6 +34,7 @@ docker create \
   -v <path to data>:/config \
   -e PGID=<gid> -e PUID=<uid>  \
   -e TZ=<timezone> \
+  -e USERS=no \
   -p 9000:9000 \
   linuxserver/thelounge
 ```
@@ -51,6 +52,7 @@ http://192.168.x.x:8080 would show you what's running INSIDE the container on po
 * `-e PGID` for GroupID - see below for explanation
 * `-e PUID` for UserID - see below for explanation
 * `-e TZ` for timezone information, eg Europe/London
+* `-e USERS` set to yes to enable user accounts (See [Set up user accounts](#add-user-accounts))
 
 It is based on alpine linux with s6 overlay, for shell access whilst the container is running do `docker exec -it thelounge /bin/bash`.
 
@@ -69,15 +71,15 @@ In this instance `PUID=1001` and `PGID=1001`. To find yours use `id user` as bel
 
 To log in to the application, browse to https://<hostip>:9000.
 
-To setup user account(s)
+### Add user accounts
 
-+ edit /config/config.json changing the value `public: true,` to `public: false,`  restart the container and enter the following from the command line of the host.
+If you want to add user accounts you must create the container with the `-e USERS` set to yes. See [Usage](#usage).
 
-+ `docker exec -it thelounge node /app/node_modules/thelounge/index.js --home /config add <user>`
+`docker exec -it thelounge node /app/node_modules/thelounge/index.js --home /config add <user>`
 
-+ Enter a password when prompted, refresh your browser.
+You will be asked to type a password. You can add more users by running the command again with a new username. Then reboot your container using `docker restart shout`
 
-+ You should now be prompted for a password on the webinterface.
+You should now be prompted for a password on the webinterface.
 
 
  

--- a/root/etc/services.d/thelounge/run
+++ b/root/etc/services.d/thelounge/run
@@ -2,5 +2,11 @@
 
 cd /app/node_modules/thelounge || exit
 
-exec \
-	s6-setuidgid abc node index.js --home /config start
+if [ $USERS == Y ] || [ $USERS == y ] || [ $USERS == Yes ] || [ $USERS == yes ] || [ $USERS == YES ]
+then
+	exec \
+		s6-setuidgid abc node index.js --private --home /config start
+else
+	exec \
+		s6-setuidgid abc node index.js --home /config start
+fi


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

[linuxserverurl]: https://linuxserver.io
[![linuxserver.io](https://raw.githubusercontent.com/linuxserver/docker-templates/master/linuxserver.io/img/linuxserver_medium.png)][linuxserverurl]
	

Long story short, first I made this PR for linuxserver/docker-shout-irc then I realize that said repo is deprecated. Thus, I check out this current repo, and see there is user support. However to enable it the end user has to edit text files. So I ported the changes I made over to this current repo. The old method still works. But in addition you can set `-e USERS=yes` and it will just work. Of course you still need to create a user using the same `docker exec` command. But this just follows best practice standards. And is easier for new users to follow. 😄 
