### PR TITLE
Use s6 logutil-service for saving stdout/stderr to file

### DIFF
--- a/root/etc/cont-init.d/30-config
+++ b/root/etc/cont-init.d/30-config
@@ -3,3 +3,6 @@
 # permissions
 chown -R abc:abc \
 	/config
+# logs
+mkdir -p /var/log/thelounge
+chown -R nobody:nobody /var/log/thelounge

--- a/root/etc/services.d/thelounge/log/run
+++ b/root/etc/services.d/thelounge/log/run
@@ -1,0 +1,2 @@
+#!/bin/sh
+exec logutil-service /var/log/thelounge

--- a/root/etc/services.d/thelounge/run
+++ b/root/etc/services.d/thelounge/run
@@ -3,4 +3,4 @@
 cd /app/node_modules/thelounge || exit
 
 exec \
-	s6-setuidgid abc node index.js start
+	s6-setuidgid abc node index.js start 2>&1


### PR DESCRIPTION
`logutil-service` handles logging to a file as well as logrotation.

All output directly from thelounge is written to a file. Docker run output is not touched.

<img width="691" alt="log_file" src="https://user-images.githubusercontent.com/5432956/37570476-ae49dcf0-2ac6-11e8-8633-5b23cc3a3fa9.png">
<img width="553" alt="docker_run" src="https://user-images.githubusercontent.com/5432956/37570477-b1c1618c-2ac6-11e8-9566-4eb08dbf6df5.png">


Logging to a file would allow fail2ban to check for failed login attempts once this code tagged in a release: https://github.com/thelounge/thelounge/pull/2247

