### PR TITLE
Improvements for application setup block

### DIFF
--- a/readme-vars.yml
+++ b/readme-vars.yml
@@ -30,7 +30,6 @@ param_ports:
 app_setup_block_enabled: true
 app_setup_block: "
 * When the application first runs, it will populate its /config
-  * (be sure you have user permissions matched between the host and the container by using PUID and PGID)
   
 * Stop the container
 
@@ -50,7 +49,7 @@ app_setup_block: "
   
   * Saving logs to disk is the default, this consumes more space but allows scrollback.
 
-* To log in to the application, browse to http://<hostip>:9000
+* To log in to the application, browse to `http://<hostip>:9000`
 
 * You should now be prompted for a username and password on the webinterface.
 

--- a/readme-vars.yml
+++ b/readme-vars.yml
@@ -29,21 +29,28 @@ param_ports:
 # application setup block
 app_setup_block_enabled: true
 app_setup_block: "
-* When the application first runs, it will populate its /config (be sure you have user permissions matched between the host and the container)
+* When the application first runs, it will populate its /config
+  * (be sure you have user permissions matched between the host and the container by using PUID and PGID)
+  
+* Stop the container
 
-* From the host, edit `/config/config.js`, wherever you've mapped it, with the container stopped
+* Now from the host, edit `/config/config.js`, wherever you've mapped it
+  
+  * In most cases you want the value `public: false` to allow named users only
+  
+  * Setting the two prefetch values to true improves usability, but uses more storage
 
-** In most cases you want the value `public: false` to allow named users only
-** Setting the two prefetch values to true improves usability, but uses more storage
-
-* Once you have the configuration you want, start the container again
+* Once you have the configuration you want, save it and start the container again
 
 * For each user, run the command
-** `docker exec -it thelounge s6-setuidgid abc thelounge add <user>` ## sorry this is so complicated but leaving things out causes thelounge to complain about running as root
-** You will be prompted to enter a password that will not be echoed.
-** Saving logs to disk is the default, this consumes more space but allows scrollback.
 
-* To log in to the application, browse to http://<hostip>:9000. ## if you want https, use a reverse proxy
+  * `docker exec -it thelounge s6-setuidgid abc thelounge add <user>`
+  
+  * You will be prompted to enter a password that will not be echoed.
+  
+  * Saving logs to disk is the default, this consumes more space but allows scrollback.
+
+* To log in to the application, browse to http://<hostip>:9000
 
 * You should now be prompted for a username and password on the webinterface.
 

--- a/readme-vars.yml
+++ b/readme-vars.yml
@@ -29,19 +29,25 @@ param_ports:
 # application setup block
 app_setup_block_enabled: true
 app_setup_block: "
-* To log in to the application, browse to https://<hostip>:9000.
+* When the application first runs, it will populate its /config (be sure you have user permissions matched between the host and the container)
 
-* To setup user account(s) edit `/config/config.json` 
-  
-* Change the value `public: true,` to `public: false,`
- 
-* restart the container and enter the following from the command line of the host:
-  
-* `docker exec -it thelounge thelounge add <user>`
-  
-* Enter a password when prompted, refresh your browser.
+* From the host, edit `/config/config.js`, wherever you've mapped it, with the container stopped
 
-* You should now be prompted for a password on the webinterface.
+** In most cases you want the value `public: false` to allow named users only
+** Setting the two prefetch values to true improves usability, but uses more storage
+
+* Once you have the configuration you want, start the container again
+
+* For each user, run the command
+** `docker exec -it thelounge s6-setuidgid abc thelounge add <user>` ## sorry this is so complicated but leaving things out causes thelounge to complain about running as root
+** You will be prompted to enter a password that will not be echoed.
+** Saving logs to disk is the default, this consumes more space but allows scrollback.
+
+* To log in to the application, browse to http://<hostip>:9000. ## if you want https, use a reverse proxy
+
+* You should now be prompted for a username and password on the webinterface.
+
+* Once logged in, you can add an IRC network. Some defaults are preset for Freenode.
 "
 
 # changelog


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

[linuxserverurl]: https://linuxserver.io
[![linuxserver.io](https://raw.githubusercontent.com/linuxserver/docker-templates/master/linuxserver.io/img/linuxserver_medium.png)][linuxserverurl]
	

<!--- Before submitting a pull request please check the following -->

<!---  If this is a fix for a typo in code or documentation in the README please file an issue and let us sort it out we do not need a PR  --> 
<!---  Ask yourself if this modification is something the whole userbase will benefit from, if this is a specific change for corner case functionality or plugins please look at making a Docker Mod or local script  https://blog.linuxserver.io/2019/09/14/customizing-our-containers/ -->
<!---  That if the PR is addressing an existing issue include, closes #<issue number> , in the body of the PR commit message   -->
<!---  You have included links to any files / patches etc your PR may be using in the body of the PR commit message -->
<!--- We maintain a changelog of major revisions to the container at the end of readme-vars.yml in the root of this repository, please add your changes there if appropriate -->


<!--- Coding guidelines: -->
<!--- 1. Installed packages in the Dockerfiles should be in alphabetical order -->
<!--- 2. Changes to Dockerfile should be replicated in Dockerfile.armhf and Dockerfile.aarch64 if applicable -->
<!--- 3. Indentation style (tabs vs 4 spaces vs 1 space) should match the rest of the document -->
<!--- 4. Readme is auto generated from readme-vars.yml, make your changes there -->

------------------------------

We welcome all PR’s though this doesn’t guarantee it will be accepted.

## Description:
When I tried to use this container I ran into some difficulties. I am suggesting some improvements for the application setup block that correct some outright errors and supply a bit more guidance.

Error #1: the configuration file name is config.js not config.json

Error #2: the application is not set up for https access, so http must be used. While it is possible to set up theLounge to use https internally, there is guidance that it may make more sense to set up a reverse proxy.

Warning #1: when using the add command in the original readme, thelounge makes complaints about running as root. It will be less confusing for a user if they are given a more complete command that prevents these warnings.

Warning #2: the original language is rather confusing about where the password is set and makes it seem that one is asked to set a password in the webinterface.

The rest of my changes are intended to guide the flow of setup in a way that is easy for the user to follow. I hope I have done this without getting into the weeds of too much extraneous detail.

## Benefits of this PR and context:
Frankly, only a person already familiar with thelounge as an application would be likely to make it past the errors in the current setup instructions. I'm hoping that this PR will allow more people to successfully use this container, since it seems to be about fifty-fifty whether searching for thelounge and docker will yield this container or the "official one" from thelounge.chat.

## How Has This Been Tested?
I've pasted my text block into the current README.md to verify that I don't have any glaring Markdown errors.

I've set up theLounge many times, but usually not as a container. Each of the steps I've given here has been tested against the latest version of the container running on a RancherOS instance using the provided docker_compose.yml file with only the modifications needed for PUID, PGID, TZ, and config mapping.

## Source / References:
<!--- Please include any forum posts/github links relevant to the PR -->
