### PR TITLE
Install from source using yarn

### DIFF
--- a/.github/workflows/external_trigger.yml
+++ b/.github/workflows/external_trigger.yml
@@ -18,7 +18,7 @@ jobs:
           fi
           echo "**** External trigger running off of master branch. To disable this trigger, set a Github secret named \"PAUSE_EXTERNAL_TRIGGER_THELOUNGE_MASTER\". ****"
           echo "**** Retrieving external version ****"
-          EXT_RELEASE=$(curl -sL "https://replicate.npmjs.com/registry/thelounge" |jq -r '. | .["dist-tags"].latest')
+          EXT_RELEASE=$(curl -u "${{ secrets.CR_USER }}:${{ secrets.CR_PAT }}" -sX GET "https://api.github.com/repos/thelounge/thelounge/releases/latest" | jq -r '. | .tag_name')
           if [ -z "${EXT_RELEASE}" ] || [ "${EXT_RELEASE}" == "null" ]; then
             echo "**** Can't retrieve external version, exiting ****"
             FAILURE_REASON="Can't retrieve external version for thelounge branch master"

--- a/Dockerfile
+++ b/Dockerfile
@@ -5,32 +5,44 @@ ARG BUILD_DATE
 ARG VERSION
 ARG THELOUNGE_VERSION
 LABEL build_version="Linuxserver.io version:- ${VERSION} Build-date:- ${BUILD_DATE}"
-LABEL maintainer="aptalca"
+LABEL maintainer="aptalca,nemchik"
 
 # environment settings
-ENV THELOUNGE_HOME="/config" \
-NPM_CONFIG_LOGLEVEL="info"
+ENV THELOUNGE_HOME="/config"
 
 RUN \
+  echo "**** install build packages ****" && \
+  apk add --no-cache --virtual=build-dependencies \
+    build-base \
+    git \
+    python3-dev && \
   echo "**** install runtime packages ****" && \
   apk add --no-cache \
     curl \
     jq \
-    npm && \
-  npm config set unsafe-perm true && \
+    yarn && \
   echo "**** install the lounge irc ****" && \
   if [ -z ${THELOUNGE_VERSION+x} ]; then \
-    THELOUNGE_VERSION=$(curl -sL https://replicate.npmjs.com/registry/thelounge \
-    |jq -r '. | .["dist-tags"].latest'); \
+    THELOUNGE_VERSION=$(curl -sX GET "https://api.github.com/repos/thelounge/thelounge/releases/latest" | jq -r '. | .tag_name'); \
   fi && \
   mkdir -p \
-    /app && \
-  cd /app && \
-  npm install -g \
-    thelounge@${THELOUNGE_VERSION} && \
+    /app/thelounge && \
+  curl -o \
+    /tmp/thelounge.tar.gz -L \
+    "https://github.com/thelounge/thelounge/archive/refs/tags/${THELOUNGE_VERSION}.tar.gz" && \
+  tar xf \
+    /tmp/thelounge.tar.gz -C \
+    /app/thelounge --strip-components=1 && \
+  cd /app/thelounge && \
+  yarn install && \
+  NODE_ENV=production yarn build && \
+  yarn link && \
+  yarn --non-interactive cache clean && \
   echo "**** ensure public true on startup aka no users ****" && \
-  sed -i "s/public: false,/public: true,/g" /usr/local/lib/node_modules/thelounge/defaults/config.js && \
+  sed -i "s/public: false,/public: true,/g" defaults/config.js && \
   echo "**** cleanup ****" && \
+  apk del --purge \
+    build-dependencies && \
   rm -rf \
     /root \
     /tmp/* && \

--- a/Dockerfile.aarch64
+++ b/Dockerfile.aarch64
@@ -5,38 +5,41 @@ ARG BUILD_DATE
 ARG VERSION
 ARG THELOUNGE_VERSION
 LABEL build_version="Linuxserver.io version:- ${VERSION} Build-date:- ${BUILD_DATE}"
-LABEL maintainer="aptalca"
+LABEL maintainer="aptalca,nemchik"
 
 # environment settings
-ENV THELOUNGE_HOME="/config" \
-NPM_CONFIG_LOGLEVEL="info"
+ENV THELOUNGE_HOME="/config"
 
 RUN \
   echo "**** install build packages ****" && \
   apk add --no-cache --virtual=build-dependencies \
-    gcc \
-    g++ \
-    make \
+    build-base \
+    git \
     python3-dev && \
   echo "**** install runtime packages ****" && \
   apk add --no-cache \
     curl \
     jq \
-    npm && \
-  npm config set unsafe-perm true && \
+    yarn && \
   echo "**** install the lounge irc ****" && \
   if [ -z ${THELOUNGE_VERSION+x} ]; then \
-    THELOUNGE_VERSION=$(curl -sL https://replicate.npmjs.com/registry/thelounge \
-    |jq -r '. | .["dist-tags"].latest'); \
+    THELOUNGE_VERSION=$(curl -sX GET "https://api.github.com/repos/thelounge/thelounge/releases/latest" | jq -r '. | .tag_name'); \
   fi && \
   mkdir -p \
-    /app && \
-  cd /app && \
-  npm install -g \
-    thelounge@${THELOUNGE_VERSION} \
-    sqlite3 && \
+    /app/thelounge && \
+  curl -o \
+    /tmp/thelounge.tar.gz -L \
+    "https://github.com/thelounge/thelounge/archive/refs/tags/${THELOUNGE_VERSION}.tar.gz" && \
+  tar xf \
+    /tmp/thelounge.tar.gz -C \
+    /app/thelounge --strip-components=1 && \
+  cd /app/thelounge && \
+  yarn install && \
+  NODE_ENV=production yarn build && \
+  yarn link && \
+  yarn --non-interactive cache clean && \
   echo "**** ensure public true on startup aka no users ****" && \
-  sed -i "s/public: false,/public: true,/g" /usr/local/lib/node_modules/thelounge/defaults/config.js && \
+  sed -i "s/public: false,/public: true,/g" defaults/config.js && \
   echo "**** cleanup ****" && \
   apk del --purge \
     build-dependencies && \

--- a/Dockerfile.armhf
+++ b/Dockerfile.armhf
@@ -5,38 +5,41 @@ ARG BUILD_DATE
 ARG VERSION
 ARG THELOUNGE_VERSION
 LABEL build_version="Linuxserver.io version:- ${VERSION} Build-date:- ${BUILD_DATE}"
-LABEL maintainer="aptalca"
+LABEL maintainer="aptalca,nemchik"
 
 # environment settings
-ENV THELOUNGE_HOME="/config" \
-NPM_CONFIG_LOGLEVEL="info"
+ENV THELOUNGE_HOME="/config"
 
 RUN \
   echo "**** install build packages ****" && \
   apk add --no-cache --virtual=build-dependencies \
-    gcc \
-    g++ \
-    make \
+    build-base \
+    git \
     python3-dev && \
   echo "**** install runtime packages ****" && \
   apk add --no-cache \
     curl \
     jq \
-    npm && \
-  npm config set unsafe-perm true && \
+    yarn && \
   echo "**** install the lounge irc ****" && \
   if [ -z ${THELOUNGE_VERSION+x} ]; then \
-    THELOUNGE_VERSION=$(curl -sL https://replicate.npmjs.com/registry/thelounge \
-    |jq -r '. | .["dist-tags"].latest'); \
+    THELOUNGE_VERSION=$(curl -sX GET "https://api.github.com/repos/thelounge/thelounge/releases/latest" | jq -r '. | .tag_name'); \
   fi && \
   mkdir -p \
-    /app && \
-  cd /app && \
-  npm install -g \
-    thelounge@${THELOUNGE_VERSION} \
-    sqlite3 && \
+    /app/thelounge && \
+  curl -o \
+    /tmp/thelounge.tar.gz -L \
+    "https://github.com/thelounge/thelounge/archive/refs/tags/${THELOUNGE_VERSION}.tar.gz" && \
+  tar xf \
+    /tmp/thelounge.tar.gz -C \
+    /app/thelounge --strip-components=1 && \
+  cd /app/thelounge && \
+  yarn install && \
+  NODE_ENV=production yarn build && \
+  yarn link && \
+  yarn --non-interactive cache clean && \
   echo "**** ensure public true on startup aka no users ****" && \
-  sed -i "s/public: false,/public: true,/g" /usr/local/lib/node_modules/thelounge/defaults/config.js && \
+  sed -i "s/public: false,/public: true,/g" defaults/config.js && \
   echo "**** cleanup ****" && \
   apk del --purge \
     build-dependencies && \

--- a/README.md
+++ b/README.md
@@ -255,6 +255,7 @@ Once registered you can define the dockerfile to use with `-f Dockerfile.aarch64
 
 ## Versions
 
+* **12.04.22:** - Install from source using yarn.
 * **11.04.22:** - Rebasing to alpine 3.15 and switching from python2-dev to python3-dev for building node sqlite on arm.
 * **23.01.21:** - Rebasing to alpine 3.13.
 * **02.06.20:** - Rebasing to alpine 3.12.

--- a/jenkins-vars.yml
+++ b/jenkins-vars.yml
@@ -2,16 +2,18 @@
 
 # jenkins variables
 project_name: docker-thelounge
-external_type: npm_version
+external_type: github_stable
 release_type: stable
 release_tag: latest
 ls_branch: master
 repo_vars:
+  - EXT_GIT_BRANCH = 'master'
+  - EXT_USER = 'thelounge'
+  - EXT_REPO = 'thelounge'
+  - CONTAINER_NAME = 'thelounge'
   - BUILD_VERSION_ARG = 'THELOUNGE_VERSION'
-  - EXT_NPM='thelounge'
   - LS_USER = 'linuxserver'
   - LS_REPO = 'docker-thelounge'
-  - CONTAINER_NAME = 'thelounge'
   - DOCKERHUB_IMAGE = 'linuxserver/thelounge'
   - DEV_DOCKERHUB_IMAGE = 'lsiodev/thelounge'
   - PR_DOCKERHUB_IMAGE = 'lspipepr/thelounge'

--- a/readme-vars.yml
+++ b/readme-vars.yml
@@ -65,6 +65,7 @@ app_setup_block: |
 # changelog
 
 changelogs:
+  - { date: "12.04.22:", desc: "Install from source using yarn." }
   - { date: "11.04.22:", desc: "Rebasing to alpine 3.15 and switching from python2-dev to python3-dev for building node sqlite on arm." }
   - { date: "23.01.21:", desc: "Rebasing to alpine 3.13." }
   - { date: "02.06.20:", desc: "Rebasing to alpine 3.12." }


### PR DESCRIPTION
As of https://github.com/thelounge/thelounge/releases/tag/v4.3.1 the project no longer supports installing via npm. For consistency across all available tags I have switched to using GitHub (releases, pre-releases, and commits respectively) for all of our tags, rather than installing via NPM.

Per discussion with the project staff, they now require a specific version of sqlite3 that should happen during `yarn install` and we should not need to separately install it, however we should ensure the required tools to install are available at build time.