### PR TITLE
Install from source using yarn

### DIFF
--- a/.github/workflows/external_trigger.yml
+++ b/.github/workflows/external_trigger.yml
@@ -18,7 +18,7 @@ jobs:
           fi
           echo "**** External trigger running off of next branch. To disable this trigger, set a Github secret named \"PAUSE_EXTERNAL_TRIGGER_THELOUNGE_NEXT\". ****"
           echo "**** Retrieving external version ****"
-          EXT_RELEASE=$(curl -s "https://replicate.npmjs.com/registry/thelounge" | jq -r '. | .["dist-tags"].next')
+          EXT_RELEASE=$(curl -u "${{ secrets.CR_USER }}:${{ secrets.CR_PAT }}" -sX GET "https://api.github.com/repos/thelounge/thelounge/releases" | jq -r '.[0] | .tag_name')
           if [ -z "${EXT_RELEASE}" ] || [ "${EXT_RELEASE}" == "null" ]; then
             echo "**** Can't retrieve external version, exiting ****"
             FAILURE_REASON="Can't retrieve external version for thelounge branch next"

--- a/Dockerfile
+++ b/Dockerfile
@@ -8,34 +8,38 @@ LABEL build_version="Linuxserver.io version:- ${VERSION} Build-date:- ${BUILD_DA
 LABEL maintainer="aptalca,nemchik"
 
 # environment settings
-ENV THELOUNGE_HOME="/config" \
-NPM_CONFIG_LOGLEVEL="info"
+ENV THELOUNGE_HOME="/config"
 
 RUN \
   echo "**** install build packages ****" && \
   apk add --no-cache --virtual=build-dependencies \
     build-base \
+    git \
     python3-dev && \
   echo "**** install runtime packages ****" && \
   apk add --no-cache \
     curl \
     jq \
-    nodejs \
-    npm && \
-  npm config set unsafe-perm true && \
+    yarn && \
   echo "**** install the lounge irc ****" && \
   if [ -z ${THELOUNGE_VERSION+x} ]; then \
-    THELOUNGE_VERSION=$(curl -sL https://replicate.npmjs.com/registry/thelounge \
-    | jq -r '. | .["dist-tags"].next'); \
+    THELOUNGE_VERSION=$(curl -sX GET "https://api.github.com/repos/thelounge/thelounge/releases" | jq -r '.[0] | .tag_name'); \
   fi && \
   mkdir -p \
-    /app && \
-  cd /app && \
-  npm install -g \
-    thelounge@${THELOUNGE_VERSION} \
-    sqlite3 && \
+    /app/thelounge && \
+  curl -o \
+    /tmp/thelounge.tar.gz -L \
+    "https://github.com/thelounge/thelounge/archive/refs/tags/${THELOUNGE_VERSION}.tar.gz" && \
+  tar xf \
+    /tmp/thelounge.tar.gz -C \
+    /app/thelounge --strip-components=1 && \
+  cd /app/thelounge && \
+  yarn install && \
+  NODE_ENV=production yarn build && \
+  yarn link && \
+  yarn --non-interactive cache clean && \
   echo "**** ensure public true on startup aka no users ****" && \
-  sed -i "s/public: false,/public: true,/g" /usr/local/lib/node_modules/thelounge/defaults/config.js && \
+  sed -i "s/public: false,/public: true,/g" defaults/config.js && \
   echo "**** cleanup ****" && \
   apk del --purge \
     build-dependencies && \

--- a/Dockerfile.aarch64
+++ b/Dockerfile.aarch64
@@ -8,34 +8,38 @@ LABEL build_version="Linuxserver.io version:- ${VERSION} Build-date:- ${BUILD_DA
 LABEL maintainer="aptalca,nemchik"
 
 # environment settings
-ENV THELOUNGE_HOME="/config" \
-NPM_CONFIG_LOGLEVEL="info"
+ENV THELOUNGE_HOME="/config"
 
 RUN \
   echo "**** install build packages ****" && \
   apk add --no-cache --virtual=build-dependencies \
     build-base \
+    git \
     python3-dev && \
   echo "**** install runtime packages ****" && \
   apk add --no-cache \
     curl \
     jq \
-    nodejs \
-    npm && \
-  npm config set unsafe-perm true && \
+    yarn && \
   echo "**** install the lounge irc ****" && \
   if [ -z ${THELOUNGE_VERSION+x} ]; then \
-    THELOUNGE_VERSION=$(curl -sL https://replicate.npmjs.com/registry/thelounge \
-    | jq -r '. | .["dist-tags"].next'); \
+    THELOUNGE_VERSION=$(curl -sX GET "https://api.github.com/repos/thelounge/thelounge/releases" | jq -r '.[0] | .tag_name'); \
   fi && \
   mkdir -p \
-    /app && \
-  cd /app && \
-  npm install -g \
-    thelounge@${THELOUNGE_VERSION} \
-    sqlite3 && \
+    /app/thelounge && \
+  curl -o \
+    /tmp/thelounge.tar.gz -L \
+    "https://github.com/thelounge/thelounge/archive/refs/tags/${THELOUNGE_VERSION}.tar.gz" && \
+  tar xf \
+    /tmp/thelounge.tar.gz -C \
+    /app/thelounge --strip-components=1 && \
+  cd /app/thelounge && \
+  yarn install && \
+  NODE_ENV=production yarn build && \
+  yarn link && \
+  yarn --non-interactive cache clean && \
   echo "**** ensure public true on startup aka no users ****" && \
-  sed -i "s/public: false,/public: true,/g" /usr/local/lib/node_modules/thelounge/defaults/config.js && \
+  sed -i "s/public: false,/public: true,/g" defaults/config.js && \
   echo "**** cleanup ****" && \
   apk del --purge \
     build-dependencies && \

--- a/Dockerfile.armhf
+++ b/Dockerfile.armhf
@@ -8,34 +8,38 @@ LABEL build_version="Linuxserver.io version:- ${VERSION} Build-date:- ${BUILD_DA
 LABEL maintainer="aptalca,nemchik"
 
 # environment settings
-ENV THELOUNGE_HOME="/config" \
-NPM_CONFIG_LOGLEVEL="info"
+ENV THELOUNGE_HOME="/config"
 
 RUN \
   echo "**** install build packages ****" && \
   apk add --no-cache --virtual=build-dependencies \
     build-base \
+    git \
     python3-dev && \
   echo "**** install runtime packages ****" && \
   apk add --no-cache \
     curl \
     jq \
-    nodejs \
-    npm && \
-  npm config set unsafe-perm true && \
+    yarn && \
   echo "**** install the lounge irc ****" && \
   if [ -z ${THELOUNGE_VERSION+x} ]; then \
-    THELOUNGE_VERSION=$(curl -sL https://replicate.npmjs.com/registry/thelounge \
-    | jq -r '. | .["dist-tags"].next'); \
+    THELOUNGE_VERSION=$(curl -sX GET "https://api.github.com/repos/thelounge/thelounge/releases" | jq -r '.[0] | .tag_name'); \
   fi && \
   mkdir -p \
-    /app && \
-  cd /app && \
-  npm install -g \
-    thelounge@${THELOUNGE_VERSION} \
-    sqlite3 && \
+    /app/thelounge && \
+  curl -o \
+    /tmp/thelounge.tar.gz -L \
+    "https://github.com/thelounge/thelounge/archive/refs/tags/${THELOUNGE_VERSION}.tar.gz" && \
+  tar xf \
+    /tmp/thelounge.tar.gz -C \
+    /app/thelounge --strip-components=1 && \
+  cd /app/thelounge && \
+  yarn install && \
+  NODE_ENV=production yarn build && \
+  yarn link && \
+  yarn --non-interactive cache clean && \
   echo "**** ensure public true on startup aka no users ****" && \
-  sed -i "s/public: false,/public: true,/g" /usr/local/lib/node_modules/thelounge/defaults/config.js && \
+  sed -i "s/public: false,/public: true,/g" defaults/config.js && \
   echo "**** cleanup ****" && \
   apk del --purge \
     build-dependencies && \

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -17,12 +17,13 @@ pipeline {
     GITLAB_TOKEN=credentials('b6f0f1dd-6952-4cf6-95d1-9c06380283f0')
     GITLAB_NAMESPACE=credentials('gitlab-namespace-id')
     SCARF_TOKEN=credentials('scarf_api_key')
-    JSON_URL = 'https://replicate.npmjs.com/registry/thelounge'
-    JSON_PATH = '.["dist-tags"].next'
+    EXT_GIT_BRANCH = 'master'
+    EXT_USER = 'thelounge'
+    EXT_REPO = 'thelounge'
+    CONTAINER_NAME = 'thelounge'
     BUILD_VERSION_ARG = 'THELOUNGE_VERSION'
     LS_USER = 'linuxserver'
     LS_REPO = 'docker-thelounge'
-    CONTAINER_NAME = 'thelounge'
     DOCKERHUB_IMAGE = 'linuxserver/thelounge'
     DEV_DOCKERHUB_IMAGE = 'lsiodev/thelounge'
     PR_DOCKERHUB_IMAGE = 'lspipepr/thelounge'
@@ -101,16 +102,23 @@ pipeline {
     /* ########################
        External Release Tagging
        ######################## */
-    // If this is a custom json endpoint parse the return to get external tag
-    stage("Set ENV custom_json"){
-     steps{
-       script{
-         env.EXT_RELEASE = sh(
-           script: '''curl -s ${JSON_URL} | jq -r ". | ${JSON_PATH}" ''',
-           returnStdout: true).trim()
-         env.RELEASE_LINK = env.JSON_URL
-       }
-     }
+    // If this is a devel github release use the first in an array from github to determine the ext tag
+    stage("Set ENV github_devel"){
+      steps{
+        script{
+          env.EXT_RELEASE = sh(
+            script: '''curl -H "Authorization: token ${GITHUB_TOKEN}" -s https://api.github.com/repos/${EXT_USER}/${EXT_REPO}/releases | jq -r '.[0] | .tag_name' ''',
+            returnStdout: true).trim()
+        }
+      }
+    }
+    // If this is a stable or devel github release generate the link for the build message
+    stage("Set ENV github_link"){
+      steps{
+        script{
+          env.RELEASE_LINK = 'https://github.com/' + env.EXT_USER + '/' + env.EXT_REPO + '/releases/tag/' + env.EXT_RELEASE
+        }
+      }
     }
     // Sanitize the release tag and strip illegal docker or github characters
     stage("Sanitize tag"){
@@ -911,11 +919,11 @@ pipeline {
              "tagger": {"name": "LinuxServer Jenkins","email": "jenkins@linuxserver.io","date": "'${GITHUB_DATE}'"}}' '''
         echo "Pushing New release for Tag"
         sh '''#! /bin/bash
-              echo "Data change at JSON endpoint ${JSON_URL}" > releasebody.json
+              curl -H "Authorization: token ${GITHUB_TOKEN}" -s https://api.github.com/repos/${EXT_USER}/${EXT_REPO}/releases | jq '.[0] |.body' | sed 's:^.\\(.*\\).$:\\1:' > releasebody.json
               echo '{"tag_name":"'${META_TAG}'",\
                      "target_commitish": "next",\
                      "name": "'${META_TAG}'",\
-                     "body": "**LinuxServer Changes:**\\n\\n'${LS_RELEASE_NOTES}'\\n\\n**Remote Changes:**\\n\\n' > start
+                     "body": "**LinuxServer Changes:**\\n\\n'${LS_RELEASE_NOTES}'\\n\\n**'${EXT_REPO}' Changes:**\\n\\n' > start
               printf '","draft": false,"prerelease": true}' >> releasebody.json
               paste -d'\\0' start releasebody.json > releasebody.json.done
               curl -H "Authorization: token ${GITHUB_TOKEN}" -X POST https://api.github.com/repos/${LS_USER}/${LS_REPO}/releases -d @releasebody.json.done'''

--- a/README.md
+++ b/README.md
@@ -255,6 +255,7 @@ Once registered you can define the dockerfile to use with `-f Dockerfile.aarch64
 
 ## Versions
 
+* **12.04.22:** - Install from source using yarn.
 * **11.04.22:** - Rebasing to alpine 3.15. Add tags for pre-releases.
 * **23.01.21:** - Rebasing to alpine 3.13.
 * **02.06.20:** - Rebasing to alpine 3.12.

--- a/jenkins-vars.yml
+++ b/jenkins-vars.yml
@@ -2,17 +2,18 @@
 
 # jenkins variables
 project_name: docker-thelounge
-external_type: custom_json
+external_type: github_devel
 release_type: prerelease
 release_tag: next
 ls_branch: next
 repo_vars:
-  - JSON_URL = 'https://replicate.npmjs.com/registry/thelounge'
-  - JSON_PATH = '.["dist-tags"].next'
+  - EXT_GIT_BRANCH = 'master'
+  - EXT_USER = 'thelounge'
+  - EXT_REPO = 'thelounge'
+  - CONTAINER_NAME = 'thelounge'
   - BUILD_VERSION_ARG = 'THELOUNGE_VERSION'
   - LS_USER = 'linuxserver'
   - LS_REPO = 'docker-thelounge'
-  - CONTAINER_NAME = 'thelounge'
   - DOCKERHUB_IMAGE = 'linuxserver/thelounge'
   - DEV_DOCKERHUB_IMAGE = 'lsiodev/thelounge'
   - PR_DOCKERHUB_IMAGE = 'lspipepr/thelounge'

--- a/readme-vars.yml
+++ b/readme-vars.yml
@@ -65,6 +65,7 @@ app_setup_block: |
 # changelog
 
 changelogs:
+  - { date: "12.04.22:", desc: "Install from source using yarn." }
   - { date: "11.04.22:", desc: "Rebasing to alpine 3.15. Add tags for pre-releases." }
   - { date: "23.01.21:", desc: "Rebasing to alpine 3.13." }
   - { date: "02.06.20:", desc: "Rebasing to alpine 3.12." }


### PR DESCRIPTION
As of https://github.com/thelounge/thelounge/releases/tag/v4.3.1 the project no longer supports installing via npm. For consistency across all available tags I have switched to using GitHub (releases, pre-releases, and commits respectively) for all of our tags, rather than installing via NPM.

Per discussion with the project staff, they now require a specific version of sqlite3 that should happen during `yarn install` and we should not need to separately install it, however we should ensure the required tools to install are available at build time.