### PR TITLE
Install from source using yarn

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -8,8 +8,7 @@ LABEL build_version="Linuxserver.io version:- ${VERSION} Build-date:- ${BUILD_DA
 LABEL maintainer="aptalca,nemchik"
 
 # environment settings
-ENV THELOUNGE_HOME="/config" \
-NPM_CONFIG_LOGLEVEL="info"
+ENV THELOUNGE_HOME="/config"
 
 RUN \
   echo "**** install build packages ****" && \
@@ -21,15 +20,10 @@ RUN \
   apk add --no-cache \
     curl \
     jq \
-    nodejs \
-    npm \
     yarn && \
-  npm config set unsafe-perm true && \
-  yarn config set unsafe-perm true && \
   echo "**** install the lounge irc ****" && \
   if [ -z ${THELOUNGE_COMMIT+x} ]; then \
-    THELOUNGE_COMMIT=$(curl -s https://api.github.com/repos/thelounge/thelounge/commits/master \
-    | jq -r '. | .sha' | cut -c1-8 ); \
+    THELOUNGE_COMMIT=$(curl -sX GET "https://api.github.com/repos/thelounge/thelounge/commits/master" | jq -r '. | .sha' | cut -c1-8); \
   fi && \
   mkdir -p \
     /app/thelounge && \
@@ -40,11 +34,10 @@ RUN \
     /tmp/thelounge.tar.gz -C \
     /app/thelounge --strip-components=1 && \
   cd /app/thelounge && \
-  npm install -g \
-    sqlite3 && \
   yarn install && \
   NODE_ENV=production yarn build && \
-  yarn cache clean && \
+  yarn link && \
+  yarn --non-interactive cache clean && \
   echo "**** ensure public true on startup aka no users ****" && \
   sed -i "s/public: false,/public: true,/g" defaults/config.js && \
   echo "**** cleanup ****" && \

--- a/Dockerfile.aarch64
+++ b/Dockerfile.aarch64
@@ -8,8 +8,7 @@ LABEL build_version="Linuxserver.io version:- ${VERSION} Build-date:- ${BUILD_DA
 LABEL maintainer="aptalca,nemchik"
 
 # environment settings
-ENV THELOUNGE_HOME="/config" \
-NPM_CONFIG_LOGLEVEL="info"
+ENV THELOUNGE_HOME="/config"
 
 RUN \
   echo "**** install build packages ****" && \
@@ -21,15 +20,10 @@ RUN \
   apk add --no-cache \
     curl \
     jq \
-    nodejs \
-    npm \
     yarn && \
-  npm config set unsafe-perm true && \
-  yarn config set unsafe-perm true && \
   echo "**** install the lounge irc ****" && \
   if [ -z ${THELOUNGE_COMMIT+x} ]; then \
-    THELOUNGE_COMMIT=$(curl -s https://api.github.com/repos/thelounge/thelounge/commits/master \
-    | jq -r '. | .sha' | cut -c1-8 ); \
+    THELOUNGE_COMMIT=$(curl -sX GET "https://api.github.com/repos/thelounge/thelounge/commits/master" | jq -r '. | .sha' | cut -c1-8); \
   fi && \
   mkdir -p \
     /app/thelounge && \
@@ -40,11 +34,10 @@ RUN \
     /tmp/thelounge.tar.gz -C \
     /app/thelounge --strip-components=1 && \
   cd /app/thelounge && \
-  npm install -g \
-    sqlite3 && \
   yarn install && \
   NODE_ENV=production yarn build && \
-  yarn cache clean && \
+  yarn link && \
+  yarn --non-interactive cache clean && \
   echo "**** ensure public true on startup aka no users ****" && \
   sed -i "s/public: false,/public: true,/g" defaults/config.js && \
   echo "**** cleanup ****" && \

--- a/Dockerfile.armhf
+++ b/Dockerfile.armhf
@@ -8,8 +8,7 @@ LABEL build_version="Linuxserver.io version:- ${VERSION} Build-date:- ${BUILD_DA
 LABEL maintainer="aptalca,nemchik"
 
 # environment settings
-ENV THELOUNGE_HOME="/config" \
-NPM_CONFIG_LOGLEVEL="info"
+ENV THELOUNGE_HOME="/config"
 
 RUN \
   echo "**** install build packages ****" && \
@@ -21,15 +20,10 @@ RUN \
   apk add --no-cache \
     curl \
     jq \
-    nodejs \
-    npm \
     yarn && \
-  npm config set unsafe-perm true && \
-  yarn config set unsafe-perm true && \
   echo "**** install the lounge irc ****" && \
   if [ -z ${THELOUNGE_COMMIT+x} ]; then \
-    THELOUNGE_COMMIT=$(curl -s https://api.github.com/repos/thelounge/thelounge/commits/master \
-    | jq -r '. | .sha' | cut -c1-8 ); \
+    THELOUNGE_COMMIT=$(curl -sX GET "https://api.github.com/repos/thelounge/thelounge/commits/master" | jq -r '. | .sha' | cut -c1-8); \
   fi && \
   mkdir -p \
     /app/thelounge && \
@@ -40,11 +34,10 @@ RUN \
     /tmp/thelounge.tar.gz -C \
     /app/thelounge --strip-components=1 && \
   cd /app/thelounge && \
-  npm install -g \
-    sqlite3 && \
   yarn install && \
   NODE_ENV=production yarn build && \
-  yarn cache clean && \
+  yarn link && \
+  yarn --non-interactive cache clean && \
   echo "**** ensure public true on startup aka no users ****" && \
   sed -i "s/public: false,/public: true,/g" defaults/config.js && \
   echo "**** cleanup ****" && \

--- a/README.md
+++ b/README.md
@@ -255,6 +255,7 @@ Once registered you can define the dockerfile to use with `-f Dockerfile.aarch64
 
 ## Versions
 
+* **12.04.22:** - Install from source using yarn. Cleanups in nightly branch.
 * **11.04.22:** - Rebasing to alpine 3.15. Add tags for pre-releases.
 * **23.01.21:** - Rebasing to alpine 3.13.
 * **02.06.20:** - Rebasing to alpine 3.12.

--- a/readme-vars.yml
+++ b/readme-vars.yml
@@ -65,6 +65,7 @@ app_setup_block: |
 # changelog
 
 changelogs:
+  - { date: "12.04.22:", desc: "Install from source using yarn. Cleanups in nightly branch." }
   - { date: "11.04.22:", desc: "Rebasing to alpine 3.15. Add tags for pre-releases." }
   - { date: "23.01.21:", desc: "Rebasing to alpine 3.13." }
   - { date: "02.06.20:", desc: "Rebasing to alpine 3.12." }

--- a/root/etc/services.d/thelounge/run
+++ b/root/etc/services.d/thelounge/run
@@ -1,5 +1,4 @@
 #!/usr/bin/with-contenv bash
 
-cd /app/thelounge || exit
 exec \
-    s6-setuidgid abc yarn start
+    s6-setuidgid abc thelounge start


### PR DESCRIPTION
As of https://github.com/thelounge/thelounge/releases/tag/v4.3.1 the project no longer supports installing via npm. For consistency across all available tags I have switched to using GitHub (releases, pre-releases, and commits respectively) for all of our tags, rather than installing via NPM.

Per discussion with the project staff, they now require a specific version of sqlite3 that should happen during `yarn install` and we should not need to separately install it, however we should ensure the required tools to install are available at build time.